### PR TITLE
feat(image-captions): make footnotes work in image captions

### DIFF
--- a/src/insert-footnote-command.js
+++ b/src/insert-footnote-command.js
@@ -63,7 +63,7 @@ export default class InsertFootnoteCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const lastPosition = model.document.selection.getLastPosition();
-        const allowedIn = lastPosition && model.schema.findAllowedParent(lastPosition, ELEMENTS.footnoteSection);
+        const allowedIn = lastPosition && model.schema.findAllowedParent(lastPosition, ELEMENTS.footnoteReference);
         this.isEnabled = allowedIn !== null;
     }
     /**

--- a/src/insert-footnote-command.ts
+++ b/src/insert-footnote-command.ts
@@ -76,7 +76,7 @@ export default class InsertFootnoteCommand extends Command {
 	public override refresh(): void {
 		const model = this.editor.model;
 		const lastPosition = model.document.selection.getLastPosition();
-		const allowedIn = lastPosition && model.schema.findAllowedParent( lastPosition, ELEMENTS.footnoteSection );
+		const allowedIn = lastPosition && model.schema.findAllowedParent( lastPosition, ELEMENTS.footnoteReference );
 		this.isEnabled = allowedIn !== null;
 	}
 


### PR DESCRIPTION
Based on this:
https://github.com/TriliumNext/trilium-ckeditor5/pull/9 

After further investigation a more elegant solution was found.

**Initially**: Footnotes were only allowed where footnote sections are allowed. Footnote sections are the text area generated by footnotes where you can write down the reference.
**Now** Footnotes are allowed where the footnote schema tells them they are allowed.

So one can also see it as a bug fix.

To understand the change better cross-reference the change with:
https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_schema-Schema.html#function-findAllowedParent 

![image](https://github.com/user-attachments/assets/274f938d-b9ec-49f7-863a-6d618ec9b747)
